### PR TITLE
Fix requirements and add run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ conda create -n test_scformer python=3.7 rpy2 -y
 conda activate test_scformer
 pip install -r examples/test_requirements.txt
 ```
+
+# run test script
+
+```bash
+cd examples
+python3 test.py --data-source pbmc_dataset --model-dir path/to/modeldir --save-dir path/to/savedir
+```

--- a/examples/test_requirements.txt
+++ b/examples/test_requirements.txt
@@ -18,3 +18,4 @@ python-igraph<=0.9.11
 torch==1.9.1
 torchtext==0.10.1
 setuptools==59.5.0
+IPython


### PR DESCRIPTION
I added a missing dependency to `test_requirements.txt` and added a very rudimentary example of how to run the test script.

This currently fails with:
```python
Traceback (most recent call last):
  File "test.py", line 391, in <module>
    main(args)
  File "test.py", line 281, in main
    with open(vocab_file, "r") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'path/to/model/vocab.json'
```